### PR TITLE
Add new `ContextWithInherit` input to manage `onInherit` hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 transform/node_modules
+transform/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.15
+- Add new `ContextWithInherit` input to manage `onInherit` hook
+
+# 1.0.0
+- First version

--- a/assembly/input.ts
+++ b/assembly/input.ts
@@ -4,8 +4,8 @@ import { input_size, load_u8 } from "./env";
 import { Balance } from "./lib/chain";
 import { Address } from "./utils";
 
-interface Object {}
-export interface NoArgs extends Object {}
+interface Object { }
+export interface NoArgs extends Object { }
 
 @json
 export class Context<T> {
@@ -39,6 +39,13 @@ export class ContextWithTransactionAndParams<
   X
 > extends ContextWithTransaction<T> {
   arguments!: X;
+}
+
+@json
+export class ContextWithInherit<T> extends Context<T> {
+  nextBalance!: Balance;
+  nextState: T;
+  nextTransaction!: Transaction;
 }
 
 export function getContext<T>(): T {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archethicjs/ae-contract-as",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "",
   "bin": {
     "aewasm": "bin/aewasm.js"


### PR DESCRIPTION
This PR introduces a new `ContextWithInherit` input structure to enable the execution of the `onInherit` hook in WASM smart contracts.

The `onInherit` reserved hook is part of the smart contract runtime and is triggered during the inheritance process. 
This update provides the necessary context to support its correct execution